### PR TITLE
fix: inject plugin middleware after vite-internal middlewares

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -7,10 +7,10 @@ export default function serveStatic(config: Config): Plugin {
   return {
     name: "serve-static",
     configureServer(server) {
-      server.middlewares.use(middleware(config));
+      return () => server.middlewares.use(middleware(config));
     },
     configurePreviewServer(server) {
-      server.middlewares.use(middleware(config));
+      return () => server.middlewares.use(middleware(config));
     },
   };
 }


### PR DESCRIPTION
Closes #3

> The configureServer hook is called before internal middlewares are installed, so the custom middlewares will run before internal middlewares by default. If you want to inject a middleware after internal middlewares, you can return a function from configureServer, which will be called after internal middlewares are installed

https://vitejs.dev/guide/api-plugin.html#configureserver