### PR TITLE
chore: use vite's logger

### DIFF
--- a/lib/__tests__/mocks.ts
+++ b/lib/__tests__/mocks.ts
@@ -1,0 +1,12 @@
+import { Logger } from "vite";
+import { vi } from "vitest";
+
+export const mockLogger = vi.mocked<Logger>({
+  clearScreen: vi.fn(),
+  hasErrorLogged: () => false,
+  hasWarned: false,
+  info: vi.fn(),
+  warn: vi.fn(),
+  warnOnce: vi.fn(),
+  error: vi.fn(),
+});

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,16 +1,18 @@
 import { Plugin } from "vite";
 
 import { Config } from "./config.ts";
-import middleware from "./middleware.ts";
+import { createMiddleware } from "./middleware.ts";
 
 export default function serveStatic(config: Config): Plugin {
   return {
     name: "serve-static",
     configureServer(server) {
-      return () => server.middlewares.use(middleware(config));
+      const middleware = createMiddleware(config, server.config.logger);
+      return () => server.middlewares.use(middleware);
     },
     configurePreviewServer(server) {
-      return () => server.middlewares.use(middleware(config));
+      const middleware = createMiddleware(config, server.config.logger);
+      return () => server.middlewares.use(middleware);
     },
   };
 }

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -1,12 +1,18 @@
 import fs from "fs";
 import { contentType } from "mime-types";
 import path from "path";
-import { Connect } from "vite";
+import { Connect, Logger } from "vite";
 
-import { Config } from "./config.ts";
+import { Config as PluginConfig } from "./config.ts";
+import { setupLogger } from "./utils.ts";
 
-const middleware = (config: Config): Connect.NextHandleFunction => {
-  return (req, res, next) => {
+export function createMiddleware(
+  config: PluginConfig,
+  rawLogger: Logger,
+): Connect.NextHandleFunction {
+  const log = setupLogger(rawLogger);
+
+  return function serveStaticMiddleware(req, res, next) {
     if (!req.url) {
       return next();
     }
@@ -21,7 +27,7 @@ const middleware = (config: Config): Connect.NextHandleFunction => {
         if (!stats || !stats.isFile()) {
           res.writeHead(404);
           res.end("Not found");
-          console.error(`File ${filePath} is not a file`);
+          log.error(`File ${filePath} is not a file`);
           return;
         }
 
@@ -39,6 +45,4 @@ const middleware = (config: Config): Connect.NextHandleFunction => {
 
     return next();
   };
-};
-
-export default middleware;
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,22 @@
+import { LogOptions, Logger } from "vite";
+
+type LogFunction = (msg: string, options?: LogOptions) => void;
+export function setupLogger(logger: Logger) {
+  const defaultOptions = { timestamp: true };
+
+  function applyDefaultOptions(log: LogFunction): LogFunction {
+    return function (msg, options) {
+      log(msg, { ...defaultOptions, ...options });
+    };
+  }
+
+  return {
+    clearScreen: logger.clearScreen,
+    hasErrorLogged: logger.hasErrorLogged,
+    hasWarned: logger.hasWarned,
+    info: applyDefaultOptions(logger.info),
+    warn: applyDefaultOptions(logger.warn),
+    warnOnce: applyDefaultOptions(logger.warnOnce),
+    error: applyDefaultOptions(logger.error),
+  } satisfies Logger;
+}


### PR DESCRIPTION
Switches to use Vite's built-in logger instead of using `console.error` et al.