### PR TITLE
fix: use application/octet-stream as default content type

### DIFF
--- a/lib/__tests__/middleware.test.ts
+++ b/lib/__tests__/middleware.test.ts
@@ -20,13 +20,6 @@ const testConfig: Config = [
   },
 ];
 
-function expectedHeaders(length: number, type?: string) {
-  return {
-    "Content-Length": length,
-    ...(type && { "Content-Type": type }),
-  };
-}
-
 function expectYield(res: ServerResponse<Connect.IncomingMessage>) {
   expect(mockNext).toHaveBeenCalledOnce();
   expect(res.writeHead).not.toHaveBeenCalled();
@@ -62,7 +55,10 @@ describe("middleware", () => {
     middleware(req, res, mockNext);
 
     // then
-    expect(res.writeHead).toHaveBeenCalledWith(200, expectedHeaders(50, undefined));
+    expect(res.writeHead).toHaveBeenCalledWith(
+      200,
+      expect.objectContaining({ "Content-Length": 50, "Content-Type": "application/octet-stream" }),
+    );
     expect(mockCreateReadStream).toHaveBeenCalledWith("./hello");
     expect(mockPipe).toHaveBeenCalled();
     expect(mockNext).not.toHaveBeenCalled();
@@ -107,7 +103,10 @@ describe("middleware", () => {
       middleware(req, res, mockNext);
 
       // then
-      expect(res.writeHead).toHaveBeenCalledWith(200, expectedHeaders(test.size, test.type));
+      expect(res.writeHead).toHaveBeenCalledWith(
+        200,
+        expect.objectContaining({ "Content-Length": test.size, "Content-Type": test.type }),
+      );
       expect(mockCreateReadStream).toHaveBeenCalledWith(test.file);
       expect(mockPipe).toHaveBeenCalled();
       expect(mockNext).not.toHaveBeenCalled();

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -1,6 +1,6 @@
+import * as mime from "mime-types";
 import corsMiddleware from "cors";
 import fs from "fs";
-import { contentType } from "mime-types";
 import path from "path";
 import { Connect, Logger, PreviewServer, ViteDevServer } from "vite";
 
@@ -32,10 +32,10 @@ export function createMiddleware(
           return;
         }
 
-        const type = contentType(path.basename(filePath));
+        const type = mime.contentType(path.basename(filePath));
         res.writeHead(200, {
           "Content-Length": stats.size,
-          "Content-Type": type || undefined,
+          "Content-Type": type || "application/octet-stream",
         });
 
         const stream = fs.createReadStream(filePath);


### PR DESCRIPTION
Currently, the plugin returns `undefined` for the `Content-Type` header if it can't determine the MIME type. However, this causes issues in the dev server.

> Internal server error: Invalid value "undefined" for header "Content-Type"

The `mime-types` library we use [recommends using "application/octet-stream" for a fallback value](https://github.com/jshttp/mime-types#readme).

> **No fallbacks.** Instead of naively returning the first available type, `mime-types` simply returns `false`, so do `var type = mime.lookup('unrecognized') || 'application/octet-stream'`.

This patch adopts this as the new fallback value, rather than using `undefined`. Fixes #13.